### PR TITLE
59 change boosttest includes compilation is not nessesary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,8 @@ test.vcxproj.filters
 x64/
 build/*
 .vs/
-<<<<<<< HEAD
 wxWidgets/
 .vscode/
-=======
 boost/
 compile_flags.txt
->>>>>>> develop
+.cache/

--- a/README.md
+++ b/README.md
@@ -37,17 +37,9 @@ cd mz80emu
 git clone --recurse-submodules https://github.com/wxWidgets/wxWidgets.git
 ```
 Next, you have to create `boost` folder in the root folder of mz80emu, and copy the contents of boost.test library.
-It is required for the library headers to be in `mz80emu\boost\boost`, and static library files in `mz80emu\boost\stage\lib`.
+It is required for the library headers to be in `mz80emu\boost\boost`. Compilation is not needed.
 
-Here is an example how to compile `boost.test` library (can be done in standard Windows cmd)
-
-```
-cd D:\path\to\mz80emu\boost
-bootstrap.bat
-b2.exe link=static
-```
-
-Afterwards enter the root mz80emu folder using Native Tools Commands Prompt
+Enter the root mz80emu folder using Native Tools Commands Prompt
 
 ```
 cd D:\path\to\mz80emu

--- a/src/modules/test/unitTests/test.cpp
+++ b/src/modules/test/unitTests/test.cpp
@@ -1,5 +1,5 @@
 #define BOOST_TEST_MODULE testTestDll
-#include <boost/test/unit_test.hpp>
+#include <boost/test/included/unit_test.hpp>
 
 extern "C" {
     #include "..\testDll.h"

--- a/src/unitTests/misc.cpp
+++ b/src/unitTests/misc.cpp
@@ -1,5 +1,5 @@
-#define BOOST_TEST_MODULE testMz80emu
-#include <boost/test/unit_test.hpp>
+#define BOOST_TEST_MODULE header-only multiunit testMz80emu
+#include <boost/test/included/unit_test.hpp>
 
 #include "../misc.hpp"
 extern "C" {

--- a/src/unitTests/validation.cpp
+++ b/src/unitTests/validation.cpp
@@ -1,4 +1,4 @@
-#include "../../boost/boost/test/unit_test.hpp"
+#include <boost/test/unit_test.hpp>
 #include "../validation.hpp"
 
 using namespace std;
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_SUITE( testValidation )
             BOOST_TEST ( !validateDerivedInterfaceCreated(test) );
             cout.rdbuf(buffer);
             string output = string_buffer.str();
-            BOOST_TEST( output == "ERROR: New derived interface has not been created, but its values were specified (\"Derived interfaces\" section of config.txt).\n" );
+            BOOST_TEST( output == "ERROR: New derived interface array has not been created, but its interfaces were specified (\"Derived interfaces\" section of config.txt).\n" );
         }
         
     BOOST_AUTO_TEST_SUITE_END()
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_SUITE( testValidation )
             BOOST_TEST ( !validateDerivedInterfaceHasValues(test) );
             cout.rdbuf(buffer);
             string output = string_buffer.str();
-            BOOST_TEST( output == "ERROR: New derived interface has been created, but its values were not specified (\"Derived interfaces\" section of config.txt).\n" );
+            BOOST_TEST( output == "ERROR: New derived interface array has been created, but its interfaces were not specified (\"Derived interfaces\" section of config.txt).\n" );
         }
         
     BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
 - Fixed unit test errors
 - Made tests use header-only boost.test mode
 - updated compile instructions